### PR TITLE
Add command-line instructions to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,14 @@ build/
 # QMake
 Makefile
 .qmake.*
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
 
+# Build objects
+*.o
+*.rcc
+App/DeadAscend*
 
 # Mac store files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
  
 # Dead Ascend
+
 A hand-drawn, open source, point'n'click-like 2D adventure game written in Qt/QML and Javascript.
 
 "A horde of Zombies chased you to the old radio tower. Your only chance is to ascend up through the tower - solving a host of puzzles on your way to your rescue."
@@ -16,6 +17,7 @@ A hand-drawn, open source, point'n'click-like 2D adventure game written in Qt/QM
 By playing the pre-build versions above you are supporting my (indie) game productions.
 
 ## DIY Building
+
 Currently the only supported way to build and run the game is through [Qt Creator](https://www.qt.io/ide/) which usually comes bundled with [Qt](https://www.qt.io).
 It can be downloaded and installed in various ways so please refer to Qt homepage and documentation on howto get Qt Creator.
 
@@ -25,29 +27,42 @@ Once you have a fully working Qt/Qt Creator setup - you are ready to checkout an
 
    ```
    cd /path/to/projects
-   git clone git@github.com:Larpon/DeadAscend.git
+   git clone https://github.com/Larpon/DeadAscend.git
    ```
 2. Install project dependencies
 
    ```
    cd /path/to/projects/DeadAscend/extensions/
-   git clone git@github.com:Larpon/qak.git
-   git clone git@github.com:Larpon/QtFirebase.git
+   git clone https://github.com/Larpon/qak.git
+   git clone https://github.com/Larpon/QtFirebase.git
    ```
 
    **NOTE**<br>
    If you are building for Android and/or iOS you also need to setup [QtFirebase](https://github.com/Larpon/QtFirebase).
    Instructions and a working example is available [here](https://github.com/Larpon/QtFirebaseExample).
 
-3. Qt Creator
+3. Build
 
-   - Open `/path/to/projects/DeadAscend/DeadAscend.pro` in Qt Creator
-   - Choose your kit(s)
-   - Add custom process step to build profile: Projects -> Build -> Build steps -> `/usr/bin/make` / `assets` / `%{buildDir}/App`
-   ![Extra make target](https://raw.githubusercontent.com/Larpon/DeadAscend/master/docs/img/Screenshot_20180406_125946.png)
-   - Hit "Run"
+   a. Qt Creator
+
+      - Open `/path/to/projects/DeadAscend/DeadAscend.pro` in Qt Creator
+      - Choose your kit(s)
+      - Add custom process step to build profile: Projects -> Build -> Build steps -> `/usr/bin/make` / `assets` / `%{buildDir}/App`
+      ![Extra make target](https://raw.githubusercontent.com/Larpon/DeadAscend/master/docs/img/Screenshot_20180406_125946.png)
+      - Hit "Run"
+
+   b. Command line
+
+      ```
+      cd /path/to/projects/DeadAscend
+      qmake
+      make assets -C App
+      make
+      ./App/DeadAscend
+      ```
 
 ## Bugs and issues
+
 If you encounter anything odd with the game feel free to report an [issue](https://github.com/Larpon/DeadAscend/issues).
 
 If you're having trouble with QtFirebase please open an issue on the [QtFirebase project issue page](https://github.com/Larpon/QtFirebase/issues).


### PR DESCRIPTION
Also fixes the `git@` commands which work only when you have write access to the repos. Anonymous/read-only users should do HTTPS clones.

And add the qmake and make build objects to .gitignore.