### PR TITLE
QMake: Ensure that assets.rcc is created when missing

### DIFF
--- a/App/assets.pri
+++ b/App/assets.pri
@@ -4,13 +4,13 @@ android: {
 }
 
 assetsTarget.target = assets
+assetsTarget.output = $$ASSETS_OUT/assets.rcc
 assetsTarget.depends = $$PWD/assets.qrc
-assetsTarget.commands = $$[QT_HOST_BINS]/rcc -binary -no-compress -o $$ASSETS_OUT/assets.rcc $$PWD/assets.qrc # For multiple commands add: $$escape_expand(\n\t) <command> or && <command>
-
 !ios: {
-    #assetsTarget.depends += $$PWD/music.qrc
-    assetsTarget.commands += $$PWD/music.qrc
+    assetsTarget.depends += $$PWD/music.qrc
 }
+assetsTarget.commands = $$[QT_HOST_BINS]/rcc -binary -no-compress -o $$assetsTarget.output $$assetsTarget.depends
+# For multiple commands add: $$escape_expand(\n\t) <command> or && <command>
 
 Q_COMPRESS_PNG_FILES.name = COMPRESS_PNG_FILES
 Q_COMPRESS_PNG_FILES.value = NO
@@ -43,6 +43,7 @@ macos|ios: {
     #deployment.path =
     QMAKE_BUNDLE_DATA += deployment
 }
+
 QMAKE_EXTRA_TARGETS += assetsTarget
 
 !isEmpty(ASSETS_DIR) {

--- a/README.md
+++ b/README.md
@@ -56,13 +56,12 @@ Once you have a fully working Qt/Qt Creator setup - you are ready to checkout an
       ```
       cd /path/to/DeadAscend
       # BIN_DIR and ASSETS_DIR are optional
-      qmake "BIN_DIR=/usr/share/deadascend" "ASSETS_DIR=/usr/share/data/deadascend"
-      make qmake_all
+      qmake -r "BIN_DIR=/usr/bin" "ASSETS_DIR=/usr/share/deadascend"
       make assets -C App
-      make -C App
+      make
       make install
       ```
-      You can now run `./App/DeadAscend` - or if you used `BIN_DIR`: `/usr/share/deadascend/DeadAscend`
+      You can now run `./App/DeadAscend` - or if you used `BIN_DIR`: `/usr/bin/DeadAscend`
 
 ## Bugs and issues
 


### PR DESCRIPTION
Note: The relevant change here is the addition of the `output` path.
The rest is cosmetic.