### PR TITLE
Change assets target name so that make assets works

### DIFF
--- a/App/assets.pri
+++ b/App/assets.pri
@@ -3,7 +3,7 @@ android: {
     ASSETS_OUT=$$ANDROID_PACKAGE_SOURCE_DIR/assets
 }
 
-assetsTarget.target = assets
+assetsTarget.target = assetsrcc
 assetsTarget.output = $$ASSETS_OUT/assets.rcc
 assetsTarget.depends = $$PWD/assets.qrc
 !ios: {


### PR DESCRIPTION
make assets does not work for me because make thinks the assets folder is the target. Renaming the target to "assetsrcc" fixes that